### PR TITLE
Use CFBundleVersion

### DIFF
--- a/GoogleDrive/GoogleDrive.munki.recipe
+++ b/GoogleDrive/GoogleDrive.munki.recipe
@@ -2,34 +2,34 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads the latest Google Drive disk image and imports into Munki.</string>
-    <key>Identifier</key>
-    <string>com.github.dankeller.munki.GoogleDrive</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>GoogleDrive</string>
-        <key>MUNKI_REPO_SUBDIR</key>
-        <string>apps/google</string>
-        <key>pkginfo</key>
-        <dict>
-            <key>catalogs</key>
-            <array>
-                <string>testing</string>
-            </array>
-            <key>description</key>
-            <string>Google Drive sync for Mac. Access files on your computer from anywhere.</string>
-            <key>display_name</key>
-            <string>Google Drive</string>
-            <key>name</key>
-            <string>%NAME%</string>
+	<key>Description</key>
+	<string>Downloads the latest Google Drive disk image and imports into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.dankeller.munki.GoogleDrive</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>GoogleDrive</string>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/google</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Google Drive sync for Mac. Access files on your computer from anywhere.</string>
+			<key>display_name</key>
+			<string>Google Drive</string>
+			<key>name</key>
+			<string>%NAME%</string>
 			<key>minimum_os_version</key>
 			<string>10.6</string>
-            <key>unattended_install</key>
-            <true/>
-            <key>postinstall_script</key>
-            <string>#!/bin/sh
+			<key>unattended_install</key>
+			<true/>
+			<key>postinstall_script</key>
+			<string>#!/bin/sh
 
 # Appreciatively copied from
 # https://github.com/Ginja/Admin_Scripts/blob/master/google_drive_helper.rb
@@ -41,25 +41,50 @@ cp \
 chmod 6755 &apos;/Library/PrivilegedHelperTools/Google Drive Icon Helper&apos;
 chown root:procmod &apos;/Library/PrivilegedHelperTools/Google Drive Icon Helper&apos;
 </string>
-        </dict>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.0</string>
-    <key>ParentRecipe</key>
-    <string>com.github.dankeller.download.GoogleDrive</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_path</key>
-                <string>%pathname%</string>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-        </dict>
-    </array>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.dankeller.download.GoogleDrive</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/Google Drive.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleVersion</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Google Drive has releases that are not distinguished by the CFBundleShortVersionString. Warning: whitespace changes.
