### PR TITLE
GoogleDrive.munki: Fix postinstall on macOS 10.12

### DIFF
--- a/GoogleDrive/GoogleDrive.munki.recipe
+++ b/GoogleDrive/GoogleDrive.munki.recipe
@@ -38,8 +38,8 @@ cp \
         &apos;/Applications/Google Drive.app/Contents/Helpers/Google Drive Icon Helper&apos; \
         &apos;/Library/PrivilegedHelperTools/Google Drive Icon Helper&apos;
 
-chmod 6755 &apos;/Library/PrivilegedHelperTools/Google Drive Icon Helper&apos;
 chown root:procmod &apos;/Library/PrivilegedHelperTools/Google Drive Icon Helper&apos;
+chmod 6755 &apos;/Library/PrivilegedHelperTools/Google Drive Icon Helper&apos;
 </string>
 	<key>postuninstall_script</key>
 	<string>#/bin/sh


### PR DESCRIPTION
The postinstall script needs to set the setuid bit after chowning. Recent macOS versions appear to remove a setuid bit when the owner changes.

The same change was also made to Dropbox.munki recently: https://github.com/autopkg/recipes/pull/174