### PR TITLE
Google Drive is now called Backup and Sync

### DIFF
--- a/GoogleDrive/GoogleDrive.download.recipe
+++ b/GoogleDrive/GoogleDrive.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>GoogleDrive</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://dl.google.com/drive/installgoogledrive.dmg</string>
+		<string>https://dl.google.com/drive/InstallBackupAndSync.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Google Drive.app</string>
+				<string>%pathname%/Backup and Sync.app</string>
 				<key>requirement</key>
 				<string>identifier "com.google.GoogleDrive" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
 			</dict>

--- a/GoogleDrive/GoogleDrive.munki.recipe
+++ b/GoogleDrive/GoogleDrive.munki.recipe
@@ -21,7 +21,7 @@
 			<key>description</key>
 			<string>Google Drive sync for Mac. Access files on your computer from anywhere.</string>
 			<key>display_name</key>
-			<string>Google Drive</string>
+			<string>Google Backup and Sync</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>minimum_os_version</key>
@@ -35,7 +35,7 @@
 # https://github.com/Ginja/Admin_Scripts/blob/master/google_drive_helper.rb
 
 cp \
-        &apos;/Applications/Google Drive.app/Contents/Helpers/Google Drive Icon Helper&apos; \
+        &apos;/Applications/Backup and Sync.app/Contents/Helpers/Google Drive Icon Helper&apos; \
         &apos;/Library/PrivilegedHelperTools/Google Drive Icon Helper&apos;
 
 chown root:procmod &apos;/Library/PrivilegedHelperTools/Google Drive Icon Helper&apos;
@@ -60,7 +60,7 @@ rm &apos;/Library/PrivilegedHelperTools/Google Drive Icon Helper&apos;
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/Google Drive.app/Contents/Info.plist</string>
+				<string>%pathname%/Backup and Sync.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>


### PR DESCRIPTION
Internally, it still calls itself Google Drive in most places though.